### PR TITLE
critical older devices fix!

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1,0 +1,11 @@
+import store from './store'
+import { init } from './actions/init'
+import { render } from 'react-dom'
+import Root from './containers/Root'
+
+store.dispatch(init())
+
+render(
+  <Root store={store} />,
+  document.getElementById('app')
+)

--- a/client/index.js
+++ b/client/index.js
@@ -1,12 +1,3 @@
-import 'babel-polyfill'
-import store from './store'
-import { init } from './actions/init'
-import { render } from 'react-dom'
-import Root from './containers/Root'
+require('babel-polyfill');
 
-store.dispatch(init())
-
-render(
-  <Root store={store} />,
-  document.getElementById('app')
-)
+require('./app');


### PR DESCRIPTION
polyfill didn't apply the React Symbol.for(react.element) shim, causing older iOS devices and androids to fail!